### PR TITLE
Select options background color

### DIFF
--- a/Stylus_Dark.css
+++ b/Stylus_Dark.css
@@ -241,4 +241,7 @@ regexp("moz-extension://.*") {
   select {
     color: silver;
   }
+  option, optgroup {
+    background-color: #2a2a2e
+  }
 }


### PR DESCRIPTION
Fix for #4, that also affects option and optgroup tags, making them difficult to read

| Before #4  | After #4 | Fix |
| --- | --- | --- |
| ![](https://user-images.githubusercontent.com/17050347/45570506-6e40dc00-b87c-11e8-8dc3-40c3e5f31ddf.png) | ![](https://user-images.githubusercontent.com/17050347/45568653-a5ac8a00-b876-11e8-873f-82307ce97cf0.png) | ![](https://user-images.githubusercontent.com/17050347/45570081-ec03e800-b87a-11e8-8c49-842d187bc95c.png) |


