### PR TITLE
Remove exclamation mark from metadata

### DIFF
--- a/stylus-dark.user.css
+++ b/stylus-dark.user.css
@@ -1,4 +1,4 @@
-/*! ==UserStyle==
+/* ==UserStyle==
 @name         Stylus Dark
 @version      1.3.1
 @description  Dark Stylus theme based on ShadowFox


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17050347/48792733-d4cbf580-ed16-11e8-9ffd-510454450a4e.png)
This error occurs when you try to install/update current userstyle.
Stylus cannot parse metadata because of the exclamation mark at the start.

![image](https://user-images.githubusercontent.com/17050347/48792750-e0b7b780-ed16-11e8-8676-278739274787.png)
Without it — it works as expected.